### PR TITLE
Updated the readme and the github action to reduce user error.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,14 +5,9 @@ name: Build and Release YTMusicUltimate
 
 on:
   workflow_dispatch:
-    inputs:
-      sdk_version:
-        description: "iOS SDK version to be used during build (don't change it if you don't know what you are doing)"
-        default: "16.2"
-        required: true
-        type: string   
+    inputs: 
       decrypted_youtube_music_url:
-        description: "The direct URL to the decrypted YouTube Music ipa (I recommend using Dropbox, Google Drive is causing errors)"
+        description: "The direct URL to the decrypted YouTube Music ipa (Upload a decrypted .ipa file to Dropbox and input its URL here.)"
         default: ""
         required: true
         type: string    
@@ -54,7 +49,7 @@ jobs:
         id: SDK
         uses: actions/cache@v4.0.1
         env:
-          cache-name: iOS-${{ inputs.sdk_version }}-SDK
+          cache-name: iOS-${{ "16.2" }}-SDK
         with:
           path: theos/sdks/
           key: ${{ env.cache-name }}
@@ -65,7 +60,7 @@ jobs:
         run: |
           git clone --quiet -n --depth=1 --filter=tree:0 https://github.com/arichorn/sdks/
           cd sdks
-          git sparse-checkout set --no-cone iPhoneOS${{ inputs.sdk_version }}.sdk
+          git sparse-checkout set --no-cone iPhoneOS${{ "16.2" }}.sdk
           git checkout
           mv *.sdk $THEOS/sdks
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         id: SDK
         uses: actions/cache@v4.0.1
         env:
-          cache-name: iOS-${{ "16.2" }}-SDK
+          cache-name: iOS-16.2-SDK
         with:
           path: theos/sdks/
           key: ${{ env.cache-name }}
@@ -60,7 +60,7 @@ jobs:
         run: |
           git clone --quiet -n --depth=1 --filter=tree:0 https://github.com/arichorn/sdks/
           cd sdks
-          git sparse-checkout set --no-cone iPhoneOS${{ "16.2" }}.sdk
+          git sparse-checkout set --no-cone iPhoneOS16.2.sdk
           git checkout
           mv *.sdk $THEOS/sdks
         env:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Add __[https://ginsu.dev/repo](https://ginsu.dev/repo)__ to your favorite instal
 
 ## How to build a YTMusicUltimate IPA by yourself using Github actions
 
+If this is not your first time, skip steps 1 and 2. Instead, click on the "Sync fork" button to get the latest version of the tweak before step 3.
+
 1. Fork this repository using the fork button on the top right.
 2. On your forked repository, go to Repository Settings > Actions, enable Read and Write permissions.
 3. Go to the Actions tab on your forked repo, click on "Build and Release YTMusicUltimate" located on the left side. Click "Run workflow" button located on the right side.

--- a/README.md
+++ b/README.md
@@ -18,13 +18,23 @@ Add __[https://ginsu.dev/repo](https://ginsu.dev/repo)__ to your favorite instal
 
 (arm.deb version for Rootful and arm64.deb version for Rootless devices)
 
+* **Sideloading:**
+  We no longer provide a sideloading IPA but you can build one yourself, keep reading:
+
 ## How to build a YTMusicUltimate IPA by yourself using Github actions
 
 1. Fork this repository using the fork button on the top right.
 2. On your forked repository, go to Repository Settings > Actions, enable Read and Write permissions.
-3. Go to the Actions tab on your forked repo, click on "Build and Release YTMusicUltimate" located on the left side.
-4. Click "Run workflow" button located on the right side. Provide a URL for a decrypted YTMusic ipa(Providing YTMusic IPA is prohibited, you must find the IPA by yourself, don't ask for one). Click "Run workflow" again.
-5. You can download the tweaked IPA from the releases section of your repo after the build finishes.
+3. Go to the Actions tab on your forked repo, click on "Build and Release YTMusicUltimate" located on the left side. Click "Run workflow" button located on the right side.
+4. Provide a URL for a decrypted YTMusic IPA. ***ANY OTHER EXTENSION WON'T WORK, find a decrypted .IPA and upload into a file provider i.e DROPBOX***
+5. Click "Run workflow" again. You can download the tweaked IPA from the releases section of your repo after the build finishes. (**Go to your forked repo and add /releases to the url i.e https://github.com/YOURUSERNAME/YTMusicUltimate/releases**)
+
+## IPA building troubleshooting(I can't build the IPA/Github action fails/I can't find the releases section etc.)
+
+99.9% of the time, the culprit is the IPA URL you provided. You HAVE TO provide a decryped IPA. It cannot be any other extension, it has to be a **.ipa**. Find the decrypted IPA(no we can't help you, use your googling skills or give up), upload it to Dropbox, give the URL to the github action. It'll work, pinky promise.
+
+If the github action works and you cannot find the final ipa, you need to add /releases to the url of your forked repository. Its probably something like this: https://github.com/YOURUSERNAME/YTMusicUltimate/releases replace the YOURUSERNAME part with your username. It may seem invisible but if the github action is successful, ipa is there.
+
 
 ## How to build the package by yourself on your device
 1. Install __[Theos](https://theos.dev/docs/installation)__


### PR DESCRIPTION
I also recommend putting the following sentence to every release from now on(maybe even some past releases):

We no longer provide sideloading IPAs, [you can follow this guide to build your own.](https://github.com/dayanch96/YTMusicUltimate?tab=readme-ov-file#how-to-build-a-ytmusicultimate-ipa-by-yourself-using-github-actions)

`We no longer provide sideloading IPAs, [you can follow this guide to build your own.](https://github.com/dayanch96/YTMusicUltimate?tab=readme-ov-file#how-to-build-a-ytmusicultimate-ipa-by-yourself-using-github-actions)`

