### PR TITLE
Set github action environment to macos-12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build:
     name: Build YTMusicUltimate
-    runs-on: macos-latest
+    runs-on: macos-12
     permissions:
       contents: write
 


### PR DESCRIPTION
Fixes #256, occured due to Github updating macos-latest to macos-14 recently.