### PR TITLE
Update GitHub Actions workflow configuration to use a newer version of the cache action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache Theos
         id: theos
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4.2.3
         env:
           cache-name: theos_cache_67db2ab
         with:


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow configuration to use a newer version of the cache action.

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L63-R63): Updated the `actions/cache` version from `v4.0.1` to `v4.2.3`.